### PR TITLE
Allow for disabling the progressbar

### DIFF
--- a/src/appserver/static/js/templates/SlideshowSetupPage.html
+++ b/src/appserver/static/js/templates/SlideshowSetupPage.html
@@ -142,6 +142,15 @@ When the show is started, the selected pages will be displayed for the amount of
 	    <span class="help-inline"></span>
 	  </fieldset>
 	</div>
+
+	<div id="hide_progressbar_control_group" class="control-group">
+	  <fieldset>
+	    <input id="hide_progressbar" type="checkbox" name="hide_progressbar" <% if(hide_progressbar){ %>checked<% } %>>
+	    <label for="hide_progressbar">Hide progressbar</label>
+	    <span class="help-block">Hide progressbar which may reduce bandwidth consumption on slow/remote displays</span>
+	    <span class="help-inline"></span>
+	  </fieldset>
+	</div>
 		
 	<div class="controls">
 		<button id="start_show" class="btn btn-primary pull-right">Start show</button>

--- a/src/appserver/static/js/views/SlideshowSetupView.js
+++ b/src/appserver/static/js/views/SlideshowSetupView.js
@@ -140,7 +140,8 @@ define([
         	this.slideshow_progress_bar_created = false;
         	this.slideshow_is_running = false;
         	this.slideshow_invert_colors = false;
-        	
+		this.slideshow_hide_progressbar = false;
+
         	this.hide_controls_last_mouse_move = null;
         	this.ready_state_check_interval = null;
         	
@@ -446,6 +447,13 @@ define([
 	        	else{
 	        		$('[name="invert_colors"]:first', this.$el).prop("checked", false);
 	        	}
+
+	        	if(saved_show.hide_progressbar){
+	        		$('[name="hide_progressbar"]:first', this.$el).prop("checked", true);
+	        	}
+	        	else{
+	        		$('[name="hide_progressbar"]:first', this.$el).prop("checked", false);
+	        	}
 	        	
 	        	// Get a list of the options
 	        	this.makeAllViewsUnselected();
@@ -629,12 +637,14 @@ define([
         	var delay = this.getSecondsFromReadableDuration( delay_readable );
         	var hide_chrome = $('[name="hide_chrome"]:first', this.$el).prop("checked");
         	var invert_colors = $('[name="invert_colors"]:first', this.$el).prop("checked");
+        	var hide_progressbar = $('[name="hide_progressbar"]:first', this.$el).prop("checked");
         	
         	// Insert the parameters
         	saved_show.delay = delay;
         	saved_show.delay_readable = delay_readable;
         	saved_show.hide_chrome = hide_chrome;
         	saved_show.invert_colors = invert_colors;
+        	saved_show.hide_progressbar = hide_progressbar;
         	
         	// Return the result
         	return saved_show;
@@ -794,6 +804,7 @@ define([
         	store.set('view_delay_readable', saved_show.delay_readable);
         	store.set('hide_chrome', saved_show.hide_chrome);
         	store.set('invert_colors', saved_show.invert_colors);
+		store.set('hide_progressbar', saved_show.hide_progressbar);
         	
         	// Initialize the slideshow parameters so that we can run the show
         	this.slideshow_window = null;
@@ -802,6 +813,7 @@ define([
         	this.slideshow_delay = saved_show.delay;
         	this.slideshow_hide_chrome = saved_show.hide_chrome;
         	this.slideshow_invert_colors = saved_show.invert_colors;
+		this.slideshow_hide_progressbar = saved_show.hide_progressbar;
         	
         	// Note that the show has begun
         	this.slideshow_is_running = true;
@@ -1342,7 +1354,7 @@ define([
 	        			this.addStylesheet("../../static/app/slideshow/contrib/nprogress/nprogress.css", this.slideshow_window.document);
 	        			
 	               	 	// Start the progress indicator
-	        			if( !this.isInternetExplorer() ){
+	        			if( ! (this.isInternetExplorer() || this.slideshow_hide_progressbar) ){
 		               	 	NProgress.configure({
 		               	 							showSpinner: false,
 		               	 							document: this.slideshow_window.document
@@ -1725,6 +1737,7 @@ define([
         	var load_app_resources = this.getStoredValueOrDefault('load_app_resources', true);
         	var hide_chrome = this.getStoredValueOrDefault('hide_chrome', false);
         	var invert_colors = this.getStoredValueOrDefault('invert_colors', false);
+		var hide_progressbar = this.getStoredValueOrDefault('hide_progressbar', false);
 
         	// Extract a list of just the view names
         	var selected_views_names = [];
@@ -1741,7 +1754,8 @@ define([
         		saved_shows_supported: this.saved_shows_supported,
         		load_app_resources: load_app_resources,
         		hide_chrome: hide_chrome,
-        		invert_colors: invert_colors
+        		invert_colors: invert_colors,
+        		hide_progressbar: hide_progressbar
         	}) );
         	
         	// Convert the list into a nice dual-list


### PR DESCRIPTION
This generates a continues stream of refreshes by the browser which badly effects slow links or X forwarded browser displays.